### PR TITLE
Disable URL to profile page/listings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,7 +75,7 @@ module ApplicationHelper
 
     image_url = person.image.present? ? person.image.url(size) : missing_avatar(size)
 
-    link_to_unless(person.deleted?, image_tag(image_url, avatar_html_options), person)
+    link_to_unless(person.deleted? || !@is_current_community_admin, image_tag(image_url, avatar_html_options), person)
   end
 
   def large_avatar_thumb(person, options={})

--- a/app/views/conversations/_conversation_header.haml
+++ b/app/views/conversations/_conversation_header.haml
@@ -3,4 +3,4 @@
     = link_to person_inbox_path(@current_user) do
       = t("layouts.no_tribe.inbox")
     |
-    = t("conversations.show.conversation_with", person: link_to_unless(other_party[:is_deleted], other_party[:display_name], other_party[:url])).html_safe
+    = (link_to_unless(other_party[:is_deleted] || !@is_current_community_admin, other_party[:display_name], other_party[:url])).html_safe

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -51,11 +51,19 @@
 
     .home-list-author{:class => (listing.listing_images.size > 0 ? "home-list-author-with-listing-image" : "home-list-author-without-listing-image")}
       .home-list-avatar
-        = link_to(person_path(username: listing.author.username), :class => "home-fluid-thumbnail-grid-author-avatar-image") do
+        - if @is_current_community_admin == true
+          = link_to(person_path(username: listing.author.username), :class => "home-fluid-thumbnail-grid-author-avatar-image") do
+            = image_tag(listing.author.avatar.thumb || missing_avatar(:thumb))
+        - else
           = image_tag(listing.author.avatar.thumb || missing_avatar(:thumb))
+
       .home-list-author-details
-        = link_to(person_path(username: listing.author.username), :class => "home-list-author-name") do
+        - if @is_current_community_admin == true
+          = link_to(person_path(username: listing.author.username), :class => "home-list-author-name") do
+            = PersonViewUtils.person_entity_display_name(listing.author, @current_community.name_display_type)
+        - else
           = PersonViewUtils.person_entity_display_name(listing.author, @current_community.name_display_type)
+
         .home-list-author-reviews
           - if listing.author.num_of_reviews > 0
             = icon_tag("testimonial")

--- a/app/views/inboxes/_inbox_row.haml
+++ b/app/views/inboxes/_inbox_row.haml
@@ -2,11 +2,15 @@
 
   .col-3
     .conversation-details-container
-      = link_to conversation[:other][:url] do
+      - if @is_current_community_admin == true
+        = link_to conversation[:other][:url] do
+          = image_tag conversation[:other][:avatar], :class => "conversation-avatar"
+      - else
         = image_tag conversation[:other][:avatar], :class => "conversation-avatar"
+
       .conversation-details
         .conversation-other-party-name
-          = link_to_unless conversation[:other][:is_deleted], conversation[:other][:display_name], conversation[:other][:url]
+          = link_to_unless conversation[:other][:is_deleted] || !@is_current_community_admin, conversation[:other][:display_name], conversation[:other][:url]
         .conversation-last-message-at
           = conversation[:last_activity_ago]
 

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -149,7 +149,10 @@
             = medium_avatar_thumb(@listing.author, {:class => "listing-author-avatar-image"})
           .listing-author-details
             .listing-author-name
-              = link_to PersonViewUtils.person_display_name(@listing.author, @current_community), @listing.author, :id => "listing-author-link", :class => "listing-author-name-link", :title => "#{PersonViewUtils.person_display_name(@listing.author, @current_community)}"            
+              - if @is_current_community_admin == true
+                = link_to PersonViewUtils.person_display_name(@listing.author, @current_community), @listing.author, :id => "listing-author-link", :class => "listing-author-name-link", :title => "#{PersonViewUtils.person_display_name(@listing.author, @current_community)}"
+              - else
+                = PersonViewUtils.person_display_name(@listing.author, @current_community)
 
     - if received_testimonials.size > 0
       .row-with-divider.listing-author-activity


### PR DESCRIPTION
Disable URL to profile page/listings (Goal is only Admin can access profile page and contact users via profile page) - not essential but would be nice for admin only to contact user via profile page.

![screen shot 2017-05-24 at 5 03 51 pm](https://cloud.githubusercontent.com/assets/26615225/26410259/09c82744-40a3-11e7-9a41-8855f3c34cc8.png)

![screen shot 2017-05-24 at 5 05 05 pm](https://cloud.githubusercontent.com/assets/26615225/26410404/757fdd1a-40a3-11e7-8be7-ec8a0d27156d.png)
